### PR TITLE
Simplify Resource String Identifier

### DIFF
--- a/src/UniqueExtractor.php
+++ b/src/UniqueExtractor.php
@@ -38,8 +38,7 @@ class UniqueExtractor
             case is_array($var):
                 return 'array_'.serialize($var);
             case is_resource($var):
-                preg_match('/#([0-9]+)$/', (string)$var, $matches);
-                return 'resource_'.$matches[1];
+                return 'resource_'.get_resource_type($var).'_'.get_resource_id($var);
             case $var instanceof Generator:
                 return 'generator_'.spl_object_id($var);
             case $var instanceof Closure:

--- a/tests/unit/UniqueExtractor/NonStrictTest.php
+++ b/tests/unit/UniqueExtractor/NonStrictTest.php
@@ -192,11 +192,11 @@ class NonStrictTest extends Unit
 
     /**
      * @param resource $resource
-     * @return int
+     * @return string
      */
-    protected function getResourceId($resource): int
+    protected function getResourceId($resource): string
     {
-        preg_match('/#([0-9]+)$/', (string)$resource, $matches);
-        return (int)$matches[1];
+        return get_resource_type($resource).'_'.get_resource_id($resource);
+
     }
 }

--- a/tests/unit/UniqueExtractor/StrictTest.php
+++ b/tests/unit/UniqueExtractor/StrictTest.php
@@ -192,11 +192,10 @@ class StrictTest extends Unit
 
     /**
      * @param resource $resource
-     * @return int
+     * @return string
      */
-    protected function getResourceId($resource): int
+    protected function getResourceId($resource): string
     {
-        preg_match('/#([0-9]+)$/', (string)$resource, $matches);
-        return (int)$matches[1];
+        return get_resource_type($resource).'_'.get_resource_id($resource);
     }
 }


### PR DESCRIPTION
Hi @Smoren,

I was looking over the `UniqueExtractor` and thought the resource string could be simplified. The way it was is dependent on how PHP implements a string representation, and there is no guarantee that will not change in the future. Using the built-in resource functions seems more stable and less likely to break due to a PHP change in the future.

