### PR TITLE
Simplify resource

### DIFF
--- a/src/UniqueExtractor.php
+++ b/src/UniqueExtractor.php
@@ -38,8 +38,7 @@ class UniqueExtractor
             case is_array($var):
                 return 'array_'.serialize($var);
             case is_resource($var):
-                preg_match('/#([0-9]+)$/', (string)$var, $matches);
-                return 'resource_'.$matches[1];
+                return 'resource_'.get_resource_type($var).'_'.get_resource_id($var);
             case $var instanceof Generator:
                 return 'generator_'.spl_object_id($var);
             case $var instanceof Closure:

--- a/src/UniqueExtractor.php
+++ b/src/UniqueExtractor.php
@@ -38,7 +38,7 @@ class UniqueExtractor
             case is_array($var):
                 return 'array_'.serialize($var);
             case is_resource($var):
-                return 'resource_'.get_resource_type($var).'_'.get_resource_id($var);
+                return 'resource_'.get_resource_type($var).'_'.(string)$var;
             case $var instanceof Generator:
                 return 'generator_'.spl_object_id($var);
             case $var instanceof Closure:

--- a/tests/unit/UniqueExtractor/NonStrictTest.php
+++ b/tests/unit/UniqueExtractor/NonStrictTest.php
@@ -196,7 +196,7 @@ class NonStrictTest extends Unit
      */
     protected function getResourceId($resource): string
     {
-        return get_resource_type($resource).'_'.get_resource_id($resource);
+        return get_resource_type($resource).'_'.(string)$resource;
 
     }
 }

--- a/tests/unit/UniqueExtractor/NonStrictTest.php
+++ b/tests/unit/UniqueExtractor/NonStrictTest.php
@@ -192,11 +192,11 @@ class NonStrictTest extends Unit
 
     /**
      * @param resource $resource
-     * @return int
+     * @return string
      */
-    protected function getResourceId($resource): int
+    protected function getResourceId($resource): string
     {
-        preg_match('/#([0-9]+)$/', (string)$resource, $matches);
-        return (int)$matches[1];
+        return get_resource_type($resource).'_'.get_resource_id($resource);
+
     }
 }

--- a/tests/unit/UniqueExtractor/StrictTest.php
+++ b/tests/unit/UniqueExtractor/StrictTest.php
@@ -196,6 +196,6 @@ class StrictTest extends Unit
      */
     protected function getResourceId($resource): string
     {
-        return get_resource_type($resource).'_'.get_resource_id($resource);
+        return get_resource_type($resource).'_'.(string)$resource;
     }
 }

--- a/tests/unit/UniqueExtractor/StrictTest.php
+++ b/tests/unit/UniqueExtractor/StrictTest.php
@@ -192,11 +192,10 @@ class StrictTest extends Unit
 
     /**
      * @param resource $resource
-     * @return int
+     * @return string
      */
-    protected function getResourceId($resource): int
+    protected function getResourceId($resource): string
     {
-        preg_match('/#([0-9]+)$/', (string)$resource, $matches);
-        return (int)$matches[1];
+        return get_resource_type($resource).'_'.get_resource_id($resource);
     }
 }


### PR DESCRIPTION
Here is another option, that will work in older PHP versions. Since it is appending to a string, you could just put the entire string representation in there. No need to try to parse it, and have parsing break if PHP changes the string representation.